### PR TITLE
bblayers.conf.sample: Add meta-python

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -14,6 +14,7 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-updater-raspberrypi \
   ##OEROOT##/../meta-openembedded/meta-oe \
   ##OEROOT##/../meta-openembedded/meta-filesystems \
+  ##OEROOT##/../meta-openembedded/meta-python \
   ##OEROOT##/../meta-rust \
   "
 BBLAYERS_NON_REMOVABLE ?= " \


### PR DESCRIPTION
Add Yocto/OE layer meta-updater to bblayers as it
required for building recipe rpi-gpio for Yocto/OE
layer meta-raspberrypi.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>