### PR TITLE
conf/bblayers.conf.sample: Remove meta-rust

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -15,7 +15,6 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-openembedded/meta-oe \
   ##OEROOT##/../meta-openembedded/meta-filesystems \
   ##OEROOT##/../meta-openembedded/meta-python \
-  ##OEROOT##/../meta-rust \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ##OEROOT##/meta \


### PR DESCRIPTION
Recipe RVI SOTA Client has been removed form Yocto/OE
meta-updater and layer meta-rust is no longer needed
as a dependency.

Signed-off-by: Leon Anavi <leon.anavi@gmail.com>