### PR TITLE
u-boot-otascript: uEnv: Allow booting from non-ext4 filesystems

### DIFF
--- a/recipes-bsp/u-boot-otascript/u-boot-otascript.bb
+++ b/recipes-bsp/u-boot-otascript/u-boot-otascript.bb
@@ -4,6 +4,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 DEPENDS = "u-boot-mkimage-native"
 
+PR = "r1"
+
 COMPATIBLE_MACHINE = "raspberrypi"
 
 SRC_URI = "file://boot.scr \

--- a/recipes-bsp/u-boot-otascript/u-boot-otascript/uEnv.txt
+++ b/recipes-bsp/u-boot-otascript/u-boot-otascript/uEnv.txt
@@ -1,7 +1,7 @@
 fdt_addr_r=0x0c800000
 bootcmd_dtb=fdt addr $fdt_addr_r; fdt get value bootargs_fdt /chosen bootargs
-bootcmd_otenv=ext2load mmc 0:2 $loadaddr /boot/loader/uEnv.txt; env import -t $loadaddr $filesize
+bootcmd_otenv=load mmc 0:2 $loadaddr /boot/loader/uEnv.txt; env import -t $loadaddr $filesize
 bootcmd_args=setenv bootargs "$bootargs $bootargs_fdt ostree_root=/dev/mmcblk0p2 root=/dev/ram0 rw rootwait rootdelay=2 ramdisk_size=8192"
-bootcmd_load=ext2load mmc 0:2 $kernel_addr_r "/boot"$kernel_image
+bootcmd_load=load mmc 0:2 $kernel_addr_r "/boot"$kernel_image
 bootcmd_run=bootm $kernel_addr_r
 bootcmd=run bootcmd_otenv; run bootcmd_args; run bootcmd_load; run bootcmd_run


### PR DESCRIPTION
Basically, this makes boot script FS agnostic. For example, we can boot from BTRFS sysroot.