### PR TITLE
u-boot-otascript: uEnv: Do not load initrd separately

### DIFF
--- a/recipes-bsp/u-boot-otascript/u-boot-otascript/uEnv.txt
+++ b/recipes-bsp/u-boot-otascript/u-boot-otascript/uEnv.txt
@@ -2,6 +2,6 @@ fdt_addr_r=0x0c800000
 bootcmd_dtb=fdt addr $fdt_addr_r; fdt get value bootargs_fdt /chosen bootargs
 bootcmd_otenv=ext2load mmc 0:2 $loadaddr /boot/loader/uEnv.txt; env import -t $loadaddr $filesize
 bootcmd_args=setenv bootargs "$bootargs $bootargs_fdt ostree_root=/dev/mmcblk0p2 root=/dev/ram0 rw rootwait rootdelay=2 ramdisk_size=8192"
-bootcmd_load=ext2load mmc 0:2 $kernel_addr_r "/boot"$kernel_image; ext2load mmc 0:2 $ramdisk_addr_r "/boot"$ramdisk_image
-bootcmd_run=bootm $kernel_addr_r $ramdisk_addr_r
+bootcmd_load=ext2load mmc 0:2 $kernel_addr_r "/boot"$kernel_image
+bootcmd_run=bootm $kernel_addr_r
 bootcmd=run bootcmd_otenv; run bootcmd_args; run bootcmd_load; run bootcmd_run


### PR DESCRIPTION
If initrd (initramfs) is needed it can be part of FIT.

This depends on changes to meta-updater.