### PR TITLE
Fix pipefail issue in GPT PMBR check

### DIFF
--- a/scripts/flash-image.sh
+++ b/scripts/flash-image.sh
@@ -120,7 +120,7 @@ SECOND_PARTITION=$(fdisk -l "/dev/$DEVICE_TO_FLASH" | tail -n 1 | awk '{print $1
 # Check if there is a problem with the boot partition, and fix it if there is.
 # parted can identify the problem but apparently can't fix it without user
 # interaction.
-MISMATCH=$(fdisk -l /dev/mmcblk0 2>&1 >/dev/null | grep "GPT PMBR size mismatch")
+MISMATCH=$(fdisk -l "/dev/$DEVICE_TO_FLASH" 2>&1 >/dev/null | grep "GPT PMBR size mismatch" || true)
 if [ -n "$MISMATCH" ]; then
   echo "Fixing GPT PMBR size mismatch."
   sgdisk -e "/dev/$DEVICE_TO_FLASH"


### PR DESCRIPTION
With `set -e` the script halts if any command returns a failure, and with with `-o pipefail` any failure gets piped through. (Also, grep returns 1 if it doesn't match the string.) So unless the GPT PMBR check passes, the script will halt before resizing the partitions.