### PR TITLE
Add raspberrypi3-64 support

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Enable-FIT-and-bootcount-on-RPi3.patch
+++ b/recipes-bsp/u-boot/files/0001-Enable-FIT-and-bootcount-on-RPi3.patch
@@ -1,17 +1,32 @@
-From f265a022df419dcae1dad93dd3fe0ca321021b42 Mon Sep 17 00:00:00 2001
-From: Anton Gerasimov <anton.gerasimov@here.com>
-Date: Mon, 28 May 2018 13:27:52 +0200
+From c849889cce23b41df45cfa4efd9fde8eb682195f Mon Sep 17 00:00:00 2001
+From: Laurent Bonnans <laurent.bonnans@here.com>
+Date: Wed, 5 Jun 2019 18:12:21 +0200
 Subject: [PATCH] Enable FIT and bootcount on RPi3
 
 ---
  configs/rpi_3_32b_defconfig | 6 ++++++
- 1 file changed, 6 insertions(+)
+ configs/rpi_3_defconfig     | 6 ++++++
+ 2 files changed, 12 insertions(+)
 
 diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
-index bb56a9e4e1..55a441d2ee 100644
+index 9e142cae63..d5d32a202d 100644
 --- a/configs/rpi_3_32b_defconfig
 +++ b/configs/rpi_3_32b_defconfig
-@@ -36,3 +36,9 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -39,3 +39,9 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++
++CONFIG_BOOTCOUNT_LIMIT=y
++CONFIG_BOOTCOUNT_ENV=y
+diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
+index f46e504497..80fb70119e 100644
+--- a/configs/rpi_3_defconfig
++++ b/configs/rpi_3_defconfig
+@@ -39,3 +39,9 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
@@ -22,5 +37,6 @@ index bb56a9e4e1..55a441d2ee 100644
 +CONFIG_BOOTCOUNT_LIMIT=y
 +CONFIG_BOOTCOUNT_ENV=y
 -- 
-2.17.0
+2.20.1
+
 

--- a/recipes-bsp/u-boot/files/0001-Increase-rpi-BOOTM_LEN.patch
+++ b/recipes-bsp/u-boot/files/0001-Increase-rpi-BOOTM_LEN.patch
@@ -1,0 +1,24 @@
+From a4a9b71ac4900fee8081c85c630d55e20b233a81 Mon Sep 17 00:00:00 2001
+From: Laurent Bonnans <laurent.bonnans@here.com>
+Date: Wed, 5 Jun 2019 19:22:01 +0200
+Subject: [PATCH] Increase rpi BOOTM_LEN
+
+---
+ include/configs/rpi.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index a97550b732..4ce9b2f99e 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -56,6 +56,7 @@
+ #define CONFIG_SYS_MEMTEST_START	0x00100000
+ #define CONFIG_SYS_MEMTEST_END		0x00200000
+ #define CONFIG_LOADADDR			0x00200000
++#define CONFIG_SYS_BOOTM_LEN		SZ_64M
+ 
+ /* Devices */
+ /* GPIO */
+-- 
+2.20.1
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,4 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = " file://0001-Enable-FIT-and-bootcount-on-RPi3.patch \
-		   file://0001-board-raspberrypi-add-serial-and-revision-to-the-dev.patch"
+SRC_URI_append = " \
+                  file://0001-Enable-FIT-and-bootcount-on-RPi3.patch \
+                  file://0001-board-raspberrypi-add-serial-and-revision-to-the-dev.patch \
+                  file://0001-Increase-rpi-BOOTM_LEN.patch \
+                 "


### PR DESCRIPTION
- build u-boot with FIT support
- increase CONFIG_SYS_BOOTM_LEN, as the kernel is not self-decompressing
  (thus, much larger) on AARCH64

Also requires https://github.com/advancedtelematic/meta-updater/pull/529. Same caveat: currently building.

Also, a limitation in yocto support (I believe), is making the boot quite slow: vmlinux is not compressed in the FIT image and AArch64 kernels are much larger than arm32 as they are not self-decompressing.

I have a patch for poky that should fix that.