### PR TITLE
Generate hacked u-boot for use with qemu

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -10,3 +10,23 @@ SRC_URI_append_rpi = " \
 SRC_URI_append_raspberrypi4 = " \
                                file://rpi4-fixup-mem.cfg \
                               "
+
+# build u-boot image suitable for use with qemu
+# we need to masquerade a kernel uImage, due to qemu limitations
+# (see https://lists.nongnu.org/archive/html/qemu-devel/2019-08/msg05094.html)
+# thus, we cannot use u-boot default rule for u-boot.img which sets a correct
+# "u-boot" as image type
+
+DEPENDS_append_rpi = " u-boot-mkimage-native"
+
+UBOOT_LOAD_ADDR = "0x8000"
+UBOOT_LOAD_ADDR_raspberrypi3-64 = "0x80000"
+UBOOT_LOAD_ADDR_raspberrypi4-64 = "0x80000"
+
+do_compile_append_rpi() {
+	uboot-mkimage -A arm -T kernel -C none -O linux -a ${UBOOT_LOAD_ADDR} -e ${UBOOT_LOAD_ADDR} -d ${B}/u-boot.bin ${B}/u-boot-qemu.img
+}
+
+do_deploy_append_rpi() {
+	install -m 644 ${B}/u-boot-qemu.img ${DEPLOYDIR}/u-boot-qemu.img
+}


### PR DESCRIPTION
Some patches sent to qemu upstream bring us really close to the end-goal https://patchwork.kernel.org/project/qemu-devel/list/?series=179349.

Get them here: https://github.com/lbonn/qemu/tree/rpi-next

To build a compatible image, select a raspberrypi2 machine, add `OSTREE_KERNEL_ARGS_sota = " console=ttyAMA0,115200"` to your local.conf and run:

    qemu-system-arm -machine raspi2 -nographic -no-reboot -kernel u-boot-qemu.img -drive file=core-image-minimal-raspberrypi2.wic,format=raw

I still get a kernel panic for now but u-boot successfully switches to some linux.