### PR TITLE
Merge pull request #77 from advancedtelematic/fix/libubootenv

### DIFF
--- a/recipes-bsp/u-boot/files/fw_env.config
+++ b/recipes-bsp/u-boot/files/fw_env.config
@@ -1,0 +1,1 @@
+/mnt/bootpart/uboot.env 0x0000    0x4000

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_rpi = " \
+            file://fw_env.config \
+            "
+
+do_install_append_rpi () {
+  install -d ${D}${sysconfdir}
+  install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
+}

--- a/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,9 +1,0 @@
-
-do_install_append () {
-
-  cat >${D}${sysconfdir}/fw_env.config <<EOF
-
-/mnt/bootpart/uboot.env 0x0000    0x4000
-
-EOF
-}


### PR DESCRIPTION
Necessary after
https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=3c5a8bf487a9d52691529c35420bd38a321fbc2a

Tested on a raspberrypi4, `fw_printenv` works as expected.