### PR TITLE
linux-raspberrypi: Add rpi4 compatible uart0 dtbo

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi/0001-Add-rpi4-uart0-dtb-overlay.patch
+++ b/recipes-kernel/linux/linux-raspberrypi/0001-Add-rpi4-uart0-dtb-overlay.patch
@@ -1,0 +1,59 @@
+From cea75af3d1cc86ea8dec19cfe3c817b7c7869037 Mon Sep 17 00:00:00 2001
+From: lbonn <bonnans.l@gmail.com>
+Date: Fri, 13 Sep 2019 12:46:31 +0200
+Subject: [PATCH] Add rpi4 uart0 dtb overlay
+
+---
+ arch/arm/boot/dts/overlays/Makefile           |  2 ++
+ .../boot/dts/overlays/uart0-rpi4-overlay.dts  | 26 +++++++++++++++++++
+ 2 files changed, 28 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/uart0-rpi4-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 6b4af500f51c..634a2f252b17 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -185,6 +185,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	w1-gpio-pullup.dtbo \
+ 	wittypi.dtbo
+ 
++dtbo-$(CONFIG_ARCH_BCM2835) += uart0-rpi4.dtbo
++
+ targets += dtbs dtbs_install
+ targets += $(dtbo-y)
+ 
+diff --git a/arch/arm/boot/dts/overlays/uart0-rpi4-overlay.dts b/arch/arm/boot/dts/overlays/uart0-rpi4-overlay.dts
+new file mode 100644
+index 000000000000..048ec5755f6a
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/uart0-rpi4-overlay.dts
+@@ -0,0 +1,26 @@
++/dts-v1/;
++/plugin/;
++
++/{
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target = <&uart0>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart0_pins>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&gpio>;
++		__overlay__ {
++			uart0_pins: uart0_pins {
++				brcm,pins = <30 31 32 33>;
++				brcm,function = <7>;
++				brcm,pull = <2 0 0 2>;
++			};
++		};
++	};
++};
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -9,6 +9,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 # more details
 SRC_URI_append = " ${@oe.utils.conditional('ENABLE_AUDIO', '1', 'file://audio.patch', '', d)}"
 
+SRC_URI_append_raspberrypi4 = " file://0001-Add-rpi4-uart0-dtb-overlay.patch"
+
 do_configure_append_sota() {
     # ramblk for inird
     kernel_configure_variable BLK_DEV_RAM y


### PR DESCRIPTION
Backport a patch from branch Zeus to branch Thud to build a kernel
for Raspberry Pi 4. Needed for Automotive Grade Linux (AGL), which
support 64-bit images for Raspberry Pi 4 although it is still
based on release Thud of the Yocto Project.

(Based on git commit: 845edcac79f66edd1e1146836ed6ed6fdbf30529)

Suggested-by: Laurent Bonnans <laurent.bonnans@here.com>
Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>