### PR TITLE
Revert "u-boot: refresh patches for 2019.10."

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Increase-rpi-BOOTM_LEN.patch
+++ b/recipes-bsp/u-boot/files/0001-Increase-rpi-BOOTM_LEN.patch
@@ -1,4 +1,4 @@
-From c7d936ae239e9609d95537746600e42892f3dcfb Mon Sep 17 00:00:00 2001
+From a4a9b71ac4900fee8081c85c630d55e20b233a81 Mon Sep 17 00:00:00 2001
 From: Laurent Bonnans <laurent.bonnans@here.com>
 Date: Wed, 5 Jun 2019 19:22:01 +0200
 Subject: [PATCH] Increase rpi BOOTM_LEN
@@ -8,14 +8,17 @@ Subject: [PATCH] Increase rpi BOOTM_LEN
  1 file changed, 1 insertion(+)
 
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 77d2d5458a..dd60042200 100644
+index a97550b732..4ce9b2f99e 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -54,6 +54,7 @@
+@@ -56,6 +56,7 @@
  #define CONFIG_SYS_MEMTEST_START	0x00100000
  #define CONFIG_SYS_MEMTEST_END		0x00200000
  #define CONFIG_LOADADDR			0x00200000
 +#define CONFIG_SYS_BOOTM_LEN		SZ_64M
  
- #ifdef CONFIG_ARM64
- #define CONFIG_SYS_BOOTM_LEN		SZ_64M
+ /* Devices */
+ /* GPIO */
+-- 
+2.20.1
+

--- a/recipes-bsp/u-boot/files/0001-board-raspberrypi-add-serial-and-revision-to-the-dev.patch
+++ b/recipes-bsp/u-boot/files/0001-board-raspberrypi-add-serial-and-revision-to-the-dev.patch
@@ -1,8 +1,7 @@
-From 4a5d44fb43f2729bc588e81bfe03053f3ee04f91 Mon Sep 17 00:00:00 2001
+From 86cc911aaa958fedf2ea9cb04b4af17f5357815d Mon Sep 17 00:00:00 2001
 From: Anton Gerasimov <anton.gerasimov@here.com>
 Date: Fri, 1 Feb 2019 14:39:48 +0100
 Subject: [PATCH] board: raspberrypi: add serial and revision to the device
-
  tree
 
 Raspberry Pi bootloader adds this node to fdt, but if u-boot script
@@ -11,25 +10,24 @@ doesn't reuse the tree provided by it, this information is lost.
 Revision and serial are displayed in /proc/cpuinfo after boot.
 
 Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>
-
 ---
  board/raspberrypi/rpi/rpi.c | 31 +++++++++++++++++++++++++++++--
  1 file changed, 29 insertions(+), 2 deletions(-)
 
 diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
-index 9e0abdda31..55fcce3671 100644
+index 35f5939552..114178397e 100644
 --- a/board/raspberrypi/rpi/rpi.c
 +++ b/board/raspberrypi/rpi/rpi.c
-@@ -248,6 +248,8 @@ static uint32_t rev_scheme;
+@@ -241,6 +241,8 @@ static uint32_t rev_scheme;
  static uint32_t rev_type;
  static const struct rpi_model *model;
  
 +uint64_t serial;
 +
  #ifdef CONFIG_ARM64
- #ifndef CONFIG_BCM2711
- static struct mm_region bcm283x_mem_map[] = {
-@@ -422,8 +424,8 @@ static void set_serial_number(void)
+ static struct mm_region bcm2837_mem_map[] = {
+ 	{
+@@ -384,8 +386,8 @@ static void set_serial_number(void)
  		return;
  	}
  
@@ -40,7 +38,7 @@ index 9e0abdda31..55fcce3671 100644
  	env_set("serial#", serial_string);
  }
  
-@@ -516,6 +518,29 @@ void *board_fdt_blob_setup(void)
+@@ -478,6 +480,29 @@ void *board_fdt_blob_setup(void)
  	return (void *)fw_dtb_pointer;
  }
  
@@ -70,7 +68,7 @@ index 9e0abdda31..55fcce3671 100644
  int ft_board_setup(void *blob, bd_t *bd)
  {
  	/*
-@@ -525,6 +550,8 @@ int ft_board_setup(void *blob, bd_t *bd)
+@@ -487,6 +512,8 @@ int ft_board_setup(void *blob, bd_t *bd)
  	 */
  	lcd_dt_simplefb_add_node(blob);
  
@@ -79,3 +77,6 @@ index 9e0abdda31..55fcce3671 100644
  #ifdef CONFIG_EFI_LOADER
  	/* Reserve the spin table */
  	efi_add_memory_map(0, 1, EFI_RESERVED_MEMORY_TYPE, 0);
+-- 
+2.17.1
+


### PR DESCRIPTION
This reverts commit 18da5914a091c97f3a5c1c53f5be8eee45eed1a5.

This should not have been backported to zeus; poky in zeus is still
using u-boot 2019.07. This fixes some bitbake warnings about fuzz
applying patches. Note that there are still some warnings remaining, but
they are because of patches in meta-raspberrypi. Those are pretty
trivial so I'm not worried about that.