### PR TITLE
Fix/use kernel 4.19

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,3 +15,5 @@ LAYERSERIES_COMPAT_updater-raspberrypi = "dunfell"
 
 RPI_WIFI_ENABLE ?= "0"
 IMAGE_INSTALL_append += "${@ ' wifi-systemd-service ' if d.getVar('RPI_WIFI_ENABLE') == '1' else ''}"
+
+PREFERRED_VERSION_linux-raspberrypi = "4.19.%"


### PR DESCRIPTION
use 4.19 as preferred kernel version because meta-raspberrypi now use 5.4 but OTA demo for raspberry pi not ported to 5.4 kernel yet. it allow us have bootable builds