### PR TITLE
layer.conf: add gatesgarth to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PRIORITY_updater-raspberrypi = "7"
 
 LAYERDEPENDS_updater-raspberrypi = "sota"
 LAYERDEPENDS_updater-raspberrypi += "raspberrypi"
-LAYERSERIES_COMPAT_updater-raspberrypi = "dunfell"
+LAYERSERIES_COMPAT_updater-raspberrypi = "dunfell gatesgarth"
 
 RPI_WIFI_ENABLE ?= "0"
 IMAGE_INSTALL_append += "${@ ' wifi-systemd-service ' if d.getVar('RPI_WIFI_ENABLE') == '1' else ''}"


### PR DESCRIPTION
bitbake does not work for master after gatesgarth release. fix it

Signed-off-by: Anatoliy Odukha <aodukha@gmail.com>