### PR TITLE
Scope base-files bbappend to rpi

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,4 +1,4 @@
-do_install_append () {
+do_install_append_rpi () {
     mkdir -p ${D}/mnt/bootpart
     cat >> ${D}${sysconfdir}/fstab <<EOF
 


### PR DESCRIPTION
Similar to https://github.com/advancedtelematic/meta-updater-qemux86-64/pull/55

I have a project that I build for both raspberrypi4-64 and qemux86-64 - when I build it for QEMU, this bbappend causes boot to fail, because it adds an entry to fstab for an MMC device that QEMU does not have.
